### PR TITLE
feat(generator): add support for Hugging Face API token

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -9,6 +9,7 @@ from moshi.models import loaders
 from tokenizers.processors import TemplateProcessing
 from transformers import AutoTokenizer
 from watermarking import CSM_1B_GH_WATERMARK, load_watermarker, watermark
+import os
 
 
 @dataclass
@@ -24,7 +25,10 @@ def load_llama3_tokenizer():
     https://github.com/huggingface/transformers/issues/22794#issuecomment-2092623992
     """
     tokenizer_name = "meta-llama/Llama-3.2-1B"
-    tokenizer = AutoTokenizer.from_pretrained(tokenizer_name)
+    tokenizer = AutoTokenizer.from_pretrained(
+        tokenizer_name,
+        token = os.getenv("HF_API_TOKEN"),
+    )
     bos = tokenizer.bos_token
     eos = tokenizer.eos_token
     tokenizer._tokenizer.post_processor = TemplateProcessing(


### PR DESCRIPTION
Hello, first of all, thank you for allowing us to run CSM locally.  

I'm using the following script:  
```python
#!/usr/bin/env python3

from huggingface_hub import hf_hub_download
from generator import load_csm_1b
import torchaudio
import torch
import os

def main():
    device = "cpu"  # Forced to CPU as per original
    print(f"Using device: {device}")

    print("Downloading model...")
    model_path = hf_hub_download(repo_id="sesame/csm-1b", filename="ckpt.pt")
    print(f"Model downloaded to: {model_path}")

    print("Initializing generator...")
    # breakpoint()
    generator = load_csm_1b(model_path, device)

    print("Generating audio...")
    audio = generator.generate(
        text="Hello from Sesame.",
        speaker=0,
        context=[],
        max_audio_length_ms=10_000,
    )

    print("Saving audio file...")
    torchaudio.save("audio.wav", audio.unsqueeze(0).cpu(), generator.sample_rate)
    print("Done! Audio saved as audio.wav")

if __name__ == "__main__":
    main()
```

I encountered the following error:  
```bash
OSError: You are trying to access a gated repo.
Make sure to have access to it at https://huggingface.co/meta-llama/Llama-3.2-1B.
403 Client Error. (Request ID: Root=1-67d47b45-672861b142101992551c3b86;9c87a777-119b-49ca-822b-66b5ea1bc3ed)

Cannot access gated repo for url https://huggingface.co/meta-llama/Llama-3.2-1B/resolve/main/config.json.
Your request to access model meta-llama/Llama-3.2-1B is awaiting a review from the repo authors.
```

**Solution:**  
I added support for using the Hugging Face API token via an environment variable. Users must first export their API token:  

```bash
export HF_API_TOKEN="hf_ifpnX..."
```

With this fix, the script now works correctly:  
```bash
(csm) ➜  csm git:(main) ✗ ./test.py
Using device: cpu
Downloading model...
Model downloaded to: /home/elvis/.cache/huggingface/hub/models--sesame--csm-1b/snapshots/bf27c9b04fa0131aa912fb15860765db56e5ad1b/ckpt.pt
Initializing generator...
/home/elvis/GIT-MIRRO/csm/generator.py:179: FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`. We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.
  state_dict = torch.load(ckpt_path)
ckpt path or config path does not exist! Downloading the model from the Hugging Face Hub...
Fetching 13 files: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 13/13 [00:00<00:00, 43795.95it/s]
/home/elvis/miniconda3/envs/csm/lib/python3.10/site-packages/silentcipher/server.py:463: FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`. We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.
  self.enc_c.load_state_dict(self.convert_dataparallel_to_normal(torch.load(os.path.join(ckpt_dir, "enc_c.ckpt"), map_location=self.device)))
/home/elvis/miniconda3/envs/csm/lib/python3.10/site-packages/silentcipher/server.py:464: FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`. We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.
  self.dec_c.load_state_dict(self.convert_dataparallel_to_normal(torch.load(os.path.join(ckpt_dir, "dec_c.ckpt"), map_location=self.device)))
/home/elvis/miniconda3/envs/csm/lib/python3.10/site-packages/silentcipher/server.py:466: FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`. We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.
  m.load_state_dict(self.convert_dataparallel_to_normal(torch.load(os.path.join(ckpt_dir, f"dec_m_{i}.ckpt"), map_location=self.device)))
Generating audio...
Saving audio file...
Done! Audio saved as audio.wav
```
Greetings!