### PR TITLE
Fix max_audio_frames check

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -134,7 +134,7 @@ class Generator:
         curr_tokens_mask = prompt_tokens_mask.unsqueeze(0)
         curr_pos = torch.arange(0, prompt_tokens.size(0)).unsqueeze(0).long().to(self.device)
 
-        max_seq_len = 2048 - max_audio_frames
+        max_seq_len = max_audio_frames - 2048
         if curr_tokens.size(1) >= max_seq_len:
             raise ValueError(f"Inputs too long, must be below max_seq_len - max_audio_frames: {max_seq_len}")
 


### PR DESCRIPTION
As is, if `max_audio_length_ms` increases, this enforces a shorter audio file output. 

E.g. 

for the default 
```python
> 2048 - int(90_000 / 80)
923
```

but if you increase to 100_000
```python
> 2048 - int(100_000 / 80)
798
```

which would mean the max audio length must be shorter?

Seems like it should be flipped.